### PR TITLE
Ajout de Mayotte à epsg_from_cog

### DIFF
--- a/R/epsg_from_cog.R
+++ b/R/epsg_from_cog.R
@@ -19,7 +19,7 @@ epsg_from_cog <- function(cog) {
   proj_mart <- 5490
   proj_guad <- proj_mart
   proj_guya <- 2972
-
+  proj_mayo <- 4471
 
   if (!stringr::str_detect(cog, "^97")) {
     proj_lambert93
@@ -31,6 +31,8 @@ epsg_from_cog <- function(cog) {
     proj_guya
   } else if (stringr::str_detect(cog, "^974")) {
     proj_reun
+  } else if (stringr::str_detect(cog, "^976")) {
+    proj_mayo
   } else {
     stop("unvalide cog")
   }


### PR DESCRIPTION
`epsg_from_cog` gère bien les DROM **sauf** Mayotte (976), dont le code EPSG est le 4471 ([source](https://geodesie.ign.fr/contenu/fichiers/documentation/SRCfrance.pdf)), et il existe bien des adresses mahoraises dans les fichiers du REU.


